### PR TITLE
Revert 113 for tinker

### DIFF
--- a/beta.json
+++ b/beta.json
@@ -14,7 +14,7 @@
     "raspberrypi3-64": "0.113.0",
     "raspberrypi4": "0.113.0",
     "raspberrypi4-64": "0.113.0",
-    "tinker": "0.113.0",
+    "tinker": "0.112.4",
     "odroid-c2": "0.113.0",
     "odroid-n2": "0.113.0",
     "odroid-xu": "0.113.0"

--- a/stable.json
+++ b/stable.json
@@ -14,7 +14,7 @@
     "raspberrypi3-64": "0.113.0",
     "raspberrypi4": "0.113.0",
     "raspberrypi4-64": "0.113.0",
-    "tinker": "0.113.0",
+    "tinker": "0.112.4",
     "odroid-c2": "0.113.0",
     "odroid-n2": "0.113.0",
     "odroid-xu": "0.113.0"


### PR DESCRIPTION
It looks like the build has been failing for tinker board.
This reverts it back to 0.112.4

https://community.home-assistant.io/t/0-113-automations-scripts-and-even-more-performance/213387/64

https://hub.docker.com/r/homeassistant/tinker-homeassistant/tags